### PR TITLE
Fix enter key search bug

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-02-14T21:12:14.651884800Z">
+        <DropdownSelection timestamp="2026-02-15T23:53:35.847330900Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\sweis\.android\avd\Pixel_8.avd" />

--- a/app/src/main/res/layout/rx_search_fragment.xml
+++ b/app/src/main/res/layout/rx_search_fragment.xml
@@ -18,7 +18,8 @@
             android:id="@+id/et_search_box"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:imeOptions="actionSearch" />
+            android:imeOptions="actionSearch"
+            android:inputType="text" />
     </com.google.android.material.textfield.TextInputLayout>
 
 


### PR DESCRIPTION
Added the line `android:inputType="text"` to the `TextInputEditText` attribute of the search fragment layout .xml file. 

The Enter key is now converted to a search key when focused in the text entry box of the search bar. 