### PR TITLE
Add brand name vs generic name to search functionality

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-02-15T23:57:44.981536500Z">
+        <DropdownSelection timestamp="2026-02-20T17:52:12.436705Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=3A260DLJH0009A" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\sweis\.android\avd\Pixel_7.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-02-15T23:53:35.847330900Z">
+        <DropdownSelection timestamp="2026-02-15T23:57:44.981536500Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\sweis\.android\avd\Pixel_8.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=3A260DLJH0009A" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/example/interxactions/data/database/SearchedDrug.kt
+++ b/app/src/main/java/com/example/interxactions/data/database/SearchedDrug.kt
@@ -4,8 +4,10 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import java.io.Serializable
 
-@Entity
+@Entity(tableName = "searched_drug")
 data class SearchedDrug(
-    @PrimaryKey val drugName: String,
+    @PrimaryKey val id: String,
+    val drugName: String,
+    val drugType: String = "BRAND_NAME",
     val timestamp: Long
 ) : Serializable

--- a/app/src/main/java/com/example/interxactions/data/database/SearchedDrugDAO.kt
+++ b/app/src/main/java/com/example/interxactions/data/database/SearchedDrugDAO.kt
@@ -15,12 +15,15 @@ interface SearchedDrugDAO {
     @Delete
     suspend fun delete(drug: SearchedDrug)
 
-    @Query("DELETE FROM SearchedDrug WHERE drugName = :name")
+    @Query("DELETE FROM searched_drug WHERE drugName = :name")
     suspend fun deleteDrugByName(name: String)
 
-    @Query("SELECT * FROM SearchedDrug ORDER BY timestamp DESC")
+    @Query("DELETE FROM searched_drug WHERE id = :id")
+    suspend fun deleteDrugById(id: String)
+
+    @Query("SELECT * FROM searched_drug ORDER BY timestamp DESC")
     fun getAllSearchedDrugs(): Flow<List<SearchedDrug>>
 
-    @Query("SELECT * FROM SearchedDrug ORDER BY timestamp DESC LIMIT 1")
+    @Query("SELECT * FROM searched_drug ORDER BY timestamp DESC LIMIT 1")
     fun getMostRecentSearchedDrug(): Flow<List<SearchedDrug>>
 }

--- a/app/src/main/java/com/example/interxactions/data/database/SearchedDrugDatabase.kt
+++ b/app/src/main/java/com/example/interxactions/data/database/SearchedDrugDatabase.kt
@@ -4,13 +4,36 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [SearchedDrug::class], version = 1)
+@Database(entities = [SearchedDrug::class], version = 3)
 abstract class SearchedDrugDatabase : RoomDatabase() {
     abstract fun searchedDrugDao(): SearchedDrugDAO
 
     companion object {
         const val DATABASE_NAME = "searched-drugs-db"
+
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Check if table exists before altering
+                val cursor = db.query("SELECT name FROM sqlite_master WHERE type='table' AND name='searched_drug'")
+                if (cursor.moveToFirst()) {
+                    db.execSQL("ALTER TABLE searched_drug ADD COLUMN drugType TEXT NOT NULL DEFAULT 'BRAND_NAME'")
+                } else {
+                    // If table doesn't exist, create it (if this is a fresh installation)
+                    db.execSQL("""
+                CREATE TABLE IF NOT EXISTS searched_drug (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    drugName TEXT NOT NULL,
+                    drugType TEXT NOT NULL DEFAULT 'BRAND_NAME',
+                    timestamp INTEGER NOT NULL
+                )
+            """.trimIndent())
+                }
+                cursor.close()
+            }
+        }
 
         @Volatile private var instance: SearchedDrugDatabase? = null
 
@@ -19,7 +42,7 @@ abstract class SearchedDrugDatabase : RoomDatabase() {
                 context,
                 SearchedDrugDatabase::class.java,
                 DATABASE_NAME
-            ).build()
+            ).addMigrations(MIGRATION_2_3).build()
 
         fun getInstance(context: Context): SearchedDrugDatabase {
             return instance ?: synchronized(this) {

--- a/app/src/main/java/com/example/interxactions/data/database/SearchedDrugDatabase.kt
+++ b/app/src/main/java/com/example/interxactions/data/database/SearchedDrugDatabase.kt
@@ -14,6 +14,12 @@ abstract class SearchedDrugDatabase : RoomDatabase() {
     companion object {
         const val DATABASE_NAME = "searched-drugs-db"
 
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // Add drugType column
+                database.execSQL("ALTER TABLE SearchedDrug ADD COLUMN drugType TEXT NOT NULL DEFAULT 'GENERIC_NAME'")
+            }
+        }
         private val MIGRATION_2_3 = object : Migration(2, 3) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 // Check if table exists before altering
@@ -42,7 +48,7 @@ abstract class SearchedDrugDatabase : RoomDatabase() {
                 context,
                 SearchedDrugDatabase::class.java,
                 DATABASE_NAME
-            ).addMigrations(MIGRATION_2_3).build()
+            ).addMigrations(MIGRATION_1_2, MIGRATION_2_3).build()
 
         fun getInstance(context: Context): SearchedDrugDatabase {
             return instance ?: synchronized(this) {

--- a/app/src/main/java/com/example/interxactions/data/database/SearchedDrugDatabase.kt
+++ b/app/src/main/java/com/example/interxactions/data/database/SearchedDrugDatabase.kt
@@ -15,9 +15,9 @@ abstract class SearchedDrugDatabase : RoomDatabase() {
         const val DATABASE_NAME = "searched-drugs-db"
 
         private val MIGRATION_1_2 = object : Migration(1, 2) {
-            override fun migrate(database: SupportSQLiteDatabase) {
+            override fun migrate(db: SupportSQLiteDatabase) {
                 // Add drugType column
-                database.execSQL("ALTER TABLE SearchedDrug ADD COLUMN drugType TEXT NOT NULL DEFAULT 'GENERIC_NAME'")
+                db.execSQL("ALTER TABLE SearchedDrug ADD COLUMN drugType TEXT NOT NULL DEFAULT 'GENERIC_NAME'")
             }
         }
         private val MIGRATION_2_3 = object : Migration(2, 3) {

--- a/app/src/main/java/com/example/interxactions/data/database/SearchedDrugRepository.kt
+++ b/app/src/main/java/com/example/interxactions/data/database/SearchedDrugRepository.kt
@@ -8,6 +8,8 @@ class SearchedDrugRepository(
 
     suspend fun deleteSearchedDrugByName(name: String) = dao.deleteDrugByName(name)
 
+    suspend fun deleteSearchedDrugById(id: String) = dao.deleteDrugById(id)
+
     fun getAllSearchedDrugs() = dao.getAllSearchedDrugs()
 
     fun getMostRecentSearchedDrug() = dao.getMostRecentSearchedDrug()

--- a/app/src/main/java/com/example/interxactions/data/database/SearchedDrugViewModel.kt
+++ b/app/src/main/java/com/example/interxactions/data/database/SearchedDrugViewModel.kt
@@ -21,6 +21,12 @@ class SearchedDrugViewModel(application: Application) : AndroidViewModel(applica
         }
     }
 
+    fun deleteDrugById(id: String) {
+        viewModelScope.launch {
+            repository.deleteSearchedDrugById(id)
+        }
+    }
+
     fun addSearchedDrug(drug: SearchedDrug) {
         viewModelScope.launch {
             repository.insertSearchedDrug(drug)

--- a/app/src/main/java/com/example/interxactions/ui/AdverseEventsFragment.kt
+++ b/app/src/main/java/com/example/interxactions/ui/AdverseEventsFragment.kt
@@ -194,14 +194,11 @@ class AdverseEventsFragment : Fragment(R.layout.adverse_events_layout) {
         // Set up an observer for the most recent searched drug
         searchedDrugsViewModel.mostRecentSearchedDrug.observe(viewLifecycleOwner) { drugs ->
             val drug = drugs[0]
-            // If we have a drug then we can make the API call
-            if (drug != null) {
-                // Cache the most recent searched drug
-                cachedDrugName = drug.drugName
-                // Make the API call using the most recent searched drug
-                val query = "patient.drug.openfda.generic_name:${drug.drugName}"
-                viewModel.loadReactionOutcomeCount(query)
-            }
+            // Cache the most recent searched drug
+            cachedDrugName = drug.drugName
+            // Make the API call using the most recent searched drug
+            val query = "patient.drug.openfda.generic_name:${drug.drugName}"
+            viewModel.loadReactionOutcomeCount(query)
         }
     }
 }

--- a/app/src/main/java/com/example/interxactions/ui/AdverseEventsFragment.kt
+++ b/app/src/main/java/com/example/interxactions/ui/AdverseEventsFragment.kt
@@ -192,13 +192,14 @@ class AdverseEventsFragment : Fragment(R.layout.adverse_events_layout) {
         super.onResume()
 
         // Set up an observer for the most recent searched drug
-        searchedDrugsViewModel.mostRecentSearchedDrug.observe(viewLifecycleOwner) { drug ->
+        searchedDrugsViewModel.mostRecentSearchedDrug.observe(viewLifecycleOwner) { drugs ->
+            val drug = drugs[0]
             // If we have a drug then we can make the API call
             if (drug != null) {
                 // Cache the most recent searched drug
-                cachedDrugName = drug[0].drugName
+                cachedDrugName = drug.drugName
                 // Make the API call using the most recent searched drug
-                val query = "patient.drug.openfda.generic_name:${drug[0].drugName}"
+                val query = "patient.drug.openfda.generic_name:${drug.drugName}"
                 viewModel.loadReactionOutcomeCount(query)
             }
         }

--- a/app/src/main/java/com/example/interxactions/ui/InteractingDrugsListFragment.kt
+++ b/app/src/main/java/com/example/interxactions/ui/InteractingDrugsListFragment.kt
@@ -137,9 +137,12 @@ class InteractingDrugsListFragment : Fragment(R.layout.interacting_drugs_list_fr
         * However, Retrofit appears to be URL encoding the `+` signs, so it gets double encoded.
         * Replacing the `+` signs with a space ` ` appears to fix the issue.
         * */
-        searchedDrugsViewModel.mostRecentSearchedDrug.observe(viewLifecycleOwner) { drug ->
+        searchedDrugsViewModel.mostRecentSearchedDrug.observe(viewLifecycleOwner) { drugs ->
+            val drug = drugs[0]
+            Log.d("InteractingDrugsListFragment", "Searched drug: $drug")
+
             // Set up the RecyclerView and buttons
-            searchedDrugName = drug[0].drugName // Get the name of the drug that was searched
+            searchedDrugName = drug.drugName // Get the name of the drug that was searched
             drugNameTitle.text = getString(R.string.search_results_title, searchedDrugName) // Set the title of the drug that was searched
             Log.d("InteractingDrugsListFragment", "Searched drug outside observe: $searchedDrugName")
 

--- a/app/src/main/java/com/example/interxactions/ui/InteractingDrugsListFragment.kt
+++ b/app/src/main/java/com/example/interxactions/ui/InteractingDrugsListFragment.kt
@@ -99,6 +99,7 @@ class InteractingDrugsListFragment : Fragment(R.layout.interacting_drugs_list_fr
 
     // The name of the drug that was searched
     private lateinit var searchedDrugName: String
+    private lateinit var searchedDrugType: String
 
     private lateinit var displayListCache: List<DrugInteractionsDisplay>
 
@@ -143,10 +144,11 @@ class InteractingDrugsListFragment : Fragment(R.layout.interacting_drugs_list_fr
 
             // Set up the RecyclerView and buttons
             searchedDrugName = drug.drugName // Get the name of the drug that was searched
+            searchedDrugType = drug.drugType
             drugNameTitle.text = getString(R.string.search_results_title, searchedDrugName) // Set the title of the drug that was searched
             Log.d("InteractingDrugsListFragment", "Searched drug outside observe: $searchedDrugName")
 
-            val query = "drug_interactions:$searchedDrugName AND _exists_:openfda.generic_name" // Create the query to search for drug interactions
+            val query = "drug_interactions:$searchedDrugName AND _exists_:openfda.${searchedDrugType}" // Create the query to search for drug interactions
             Log.d("InteractingDrugsListFragment", "Query: $query")
 
             viewModel.loadDrugInteractions(query) // Load the drug interactions for the given search query

--- a/app/src/main/java/com/example/interxactions/ui/RxSearchFragment.kt
+++ b/app/src/main/java/com/example/interxactions/ui/RxSearchFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import android.widget.ImageButton
+import android.widget.RadioGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -22,6 +23,7 @@ import com.google.android.material.snackbar.Snackbar
 class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
     private lateinit var searchButton: ImageButton
     private lateinit var searchBox: EditText
+    private lateinit var radioGroup: RadioGroup
     private lateinit var searchedDrugList: RecyclerView
 
     private val searchedDrugsViewModel: SearchedDrugViewModel by viewModels()
@@ -32,6 +34,7 @@ class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
         searchedDrugList = view.findViewById(R.id.searched_drug_list)
         searchBox = view.findViewById(R.id.et_search_box)
         searchButton = view.findViewById(R.id.btn_navigate)
+        radioGroup = view.findViewById(R.id.radio_group_search)
 
         setupSearchListener()
         setupSearchButton()
@@ -76,7 +79,7 @@ class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
                     (event?.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN)
 
             if (isSearchAction) {
-                if (getQuery().isNotEmpty()) {
+                if (getSearchDrugName().isNotEmpty()) {
                     performSearch()
                 } else {
                     showEmptyQueryError()
@@ -88,7 +91,7 @@ class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
 
     private fun setupSearchButton() {
         searchButton.setOnClickListener {
-            if (getQuery().isNotEmpty()) {
+            if (getSearchDrugName().isNotEmpty()) {
                 performSearch()
             } else {
                 showEmptyQueryError()
@@ -96,15 +99,23 @@ class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
         }
     }
 
-    private fun performSearch() {
-        val query = getQuery()
-        Log.d("RxSearchFragment", "Search query: $query")
+    private fun getSearchDrugName(): String = titleCaseWithExceptions(searchBox.text.toString().trim())
 
-        searchedDrugsViewModel.addSearchedDrug(SearchedDrug(query, System.currentTimeMillis()))
+    private fun performSearch() {
+        val searchDrugName = getSearchDrugName()
+
+        // Get the selected radio button ID
+        val selectedId = radioGroup.checkedRadioButtonId
+        val selectedOption = when (selectedId) {
+            R.id.radio_option_1 -> "brand_name"
+            R.id.radio_option_2 -> "generic_name"
+            else -> "Unknown"
+        }
+        Log.d("RxSearchFragment", "Search query: $searchDrugName, Selected option: $selectedOption")
+
+        searchedDrugsViewModel.addSearchedDrug(SearchedDrug(searchDrugName, System.currentTimeMillis()))
         findNavController().navigate(RxSearchFragmentDirections.navigateToDrugReport())
     }
-
-    private fun getQuery(): String = titleCaseWithExceptions(searchBox.text.toString().trim())
 
     private fun showEmptyQueryError() {
         Snackbar.make(

--- a/app/src/main/java/com/example/interxactions/ui/RxSearchFragment.kt
+++ b/app/src/main/java/com/example/interxactions/ui/RxSearchFragment.kt
@@ -82,7 +82,7 @@ class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
                 if (getSearchDrugName().isNotEmpty()) {
                     performSearch()
                 } else {
-                    showEmptyQueryError()
+                    showEmptyTermError()
                 }
             }
             isSearchAction
@@ -94,7 +94,7 @@ class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
             if (getSearchDrugName().isNotEmpty()) {
                 performSearch()
             } else {
-                showEmptyQueryError()
+                showEmptyTermError()
             }
         }
     }
@@ -111,13 +111,13 @@ class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
             R.id.radio_option_2 -> "generic_name"
             else -> "Unknown"
         }
-        Log.d("RxSearchFragment", "Search query: $searchDrugName, Selected option: $selectedOption")
+        Log.d("RxSearchFragment", "Search term: $searchDrugName, Selected option: $selectedOption")
 
         searchedDrugsViewModel.addSearchedDrug(SearchedDrug(searchDrugName, System.currentTimeMillis()))
         findNavController().navigate(RxSearchFragmentDirections.navigateToDrugReport())
     }
 
-    private fun showEmptyQueryError() {
+    private fun showEmptyTermError() {
         Snackbar.make(
             searchBox,
             "Please enter or select a drug to search.",

--- a/app/src/main/java/com/example/interxactions/ui/RxSearchFragment.kt
+++ b/app/src/main/java/com/example/interxactions/ui/RxSearchFragment.kt
@@ -66,7 +66,7 @@ class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
                 override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
                     val searchedDrug = adapter.getItemAt(viewHolder.absoluteAdapterPosition)
 
-                    searchedDrugsViewModel.deleteDrugByName(searchedDrug.drugName)
+                    searchedDrugsViewModel.deleteDrugById(searchedDrug.id)
                 }
             }
 
@@ -113,7 +113,14 @@ class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
         }
         Log.d("RxSearchFragment", "Search term: $searchDrugName, Selected option: $selectedOption")
 
-        searchedDrugsViewModel.addSearchedDrug(SearchedDrug(searchDrugName, System.currentTimeMillis()))
+        searchedDrugsViewModel.addSearchedDrug(
+            SearchedDrug(
+                "${searchDrugName}_${selectedOption}",
+                searchDrugName,
+                selectedOption,
+                System.currentTimeMillis()
+            )
+        )
         findNavController().navigate(RxSearchFragmentDirections.navigateToDrugReport())
     }
 
@@ -129,7 +136,9 @@ class RxSearchFragment : Fragment(R.layout.rx_search_fragment) {
         Log.d("RxSearchFragment", "Clicked on drug: $drug")
 
         searchedDrugsViewModel.addSearchedDrug(SearchedDrug(
+            "${drug.drugName}_${drug.drugType}",
             drug.drugName,
+            drug.drugType,
             System.currentTimeMillis()
         ))
 

--- a/app/src/main/java/com/example/interxactions/ui/SearchedDrugsAdapter.kt
+++ b/app/src/main/java/com/example/interxactions/ui/SearchedDrugsAdapter.kt
@@ -8,6 +8,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.interxactions.R
 import com.example.interxactions.data.database.SearchedDrug
+import com.example.interxactions.utils.setDrugTypeDisplay
 import java.util.Calendar
 import java.util.Date
 
@@ -42,7 +43,8 @@ class SearchedDrugsAdapter(
         view: View,
         onClick: (SearchedDrug) -> Unit
         ) : RecyclerView.ViewHolder(view) {
-        private val drugTV: TextView = view.findViewById(R.id.tv_drug_name)
+        private val drugNameTV: TextView = view.findViewById(R.id.tv_drug_name)
+        private val drugTypeTV: TextView = view.findViewById(R.id.tv_drug_type)
         private val timestampTV: TextView = view.findViewById(R.id.tv_timestamp)
         private var currentSearchedDrug: SearchedDrug? = null
 
@@ -63,7 +65,8 @@ class SearchedDrugsAdapter(
 
         fun bind(searchedDrug: SearchedDrug) {
             currentSearchedDrug = searchedDrug
-            drugTV.text = searchedDrug.drugName
+            drugNameTV.text = searchedDrug.drugName
+            drugTypeTV.text = setDrugTypeDisplay(searchedDrug.drugType)
             timestampTV.text = calculateTime(searchedDrug.timestamp)
         }
 

--- a/app/src/main/java/com/example/interxactions/utils/StringFormattingUtils.kt
+++ b/app/src/main/java/com/example/interxactions/utils/StringFormattingUtils.kt
@@ -12,3 +12,7 @@ fun titleCaseWithExceptions(
         }
     }.joinToString(" ")
 }
+
+fun setDrugTypeDisplay(drugType: String): String {
+    return "(${titleCaseWithExceptions(drugType.split('_')[0])} search)"
+}

--- a/app/src/main/res/layout/rx_search_fragment.xml
+++ b/app/src/main/res/layout/rx_search_fragment.xml
@@ -1,53 +1,114 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/search_layout"
+    <!-- Search Container -->
+    <LinearLayout
+        android:id="@+id/container_search"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:layout_marginLeft="8dp"
-        android:layout_toStartOf="@+id/btn_navigate"
-        android:hint="@string/search_hint">
+        android:orientation="vertical"
+        android:padding="8dp">
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/et_search_box"
+        <!-- Label above search box -->
+        <TextView
+            android:id="@+id/search_label"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:imeOptions="actionSearch"
-            android:inputType="text" />
-    </com.google.android.material.textfield.TextInputLayout>
+            android:layout_marginBottom="4dp"
+            android:text="@string/search_label"
+            style="?attr/textAppearanceBodyMedium" />
 
+        <!-- Search box row -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
-    <ImageButton
-        android:id="@+id/btn_navigate"
-        style="@android:style/Widget.Holo.Light.ImageButton"
-        android:layout_width="74.5dp"
-        android:layout_height="66dp"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentEnd="true"
-        android:layout_marginRight="8dp"
-        android:scaleType="fitStart"
-        android:src="@android:drawable/ic_menu_search" />
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/search_layout"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="@string/search_hint">
 
-    <TextView
-        android:id="@+id/recent_search_title"
-        style="?attr/textAppearanceHeadline5"
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_search_box"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionSearch"
+                    android:inputType="text" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <ImageButton
+                android:id="@+id/btn_navigate"
+                style="@android:style/Widget.Holo.Light.ImageButton"
+                android:layout_width="74.5dp"
+                android:layout_height="66dp"
+                android:layout_marginLeft="8dp"
+                android:scaleType="fitStart"
+                android:src="@android:drawable/ic_menu_search" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/lbl_search_by"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/search_radio_label"
+            style="?attr/textAppearanceBodyMedium" />
+
+        <!-- Radio buttons -->
+        <RadioGroup
+            android:id="@+id/radio_group_search"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <RadioButton
+                android:id="@+id/radio_option_1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/search_radio_1"
+                android:checked="true" />
+
+            <RadioButton
+                android:id="@+id/radio_option_2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/search_radio_2"
+                android:layout_marginLeft="16dp" />
+
+        </RadioGroup>
+
+    </LinearLayout>
+
+    <!-- Recent Searches Container -->
+    <LinearLayout
+        android:id="@+id/container_recent"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/search_layout"
-        android:layout_marginHorizontal="8dp"
+        android:orientation="vertical"
         android:layout_marginTop="20dp"
-        android:text="@string/search_recent" />
+        android:paddingHorizontal="8dp">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/searched_drug_list"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/recent_search_title" />
+        <TextView
+            android:id="@+id/recent_search_title"
+            style="?attr/textAppearanceHeadline5"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/search_recent" />
 
-</RelativeLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/searched_drug_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/rx_search_fragment.xml
+++ b/app/src/main/res/layout/rx_search_fragment.xml
@@ -82,7 +82,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/search_radio_2"
-                android:layout_marginLeft="16dp" />
+                android:layout_marginStart="16dp" />
 
         </RadioGroup>
 

--- a/app/src/main/res/layout/searched_drug_list_item.xml
+++ b/app/src/main/res/layout/searched_drug_list_item.xml
@@ -6,29 +6,45 @@
     android:layout_height="wrap_content"
     android:layout_margin="8dp">
 
-    <TextView
-        android:id="@+id/tv_drug_name"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingHorizontal="16dp"
-        android:paddingVertical="32dp"
-        android:text="Drug Name"
-        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:padding="8dp">
 
-    <TextView
-        android:id="@+id/tv_timestamp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end"
-        android:paddingHorizontal="16dp"
-        android:paddingVertical="32dp"
-        android:textSize="13sp"
-        android:alpha="0.66"
-        android:text="timestamp"
-        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+        <TextView
+            android:id="@+id/tv_drug_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="10dp"
+            android:paddingVertical="32dp"
+            android:text="Drug Name"
+            android:gravity="center"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"/>
+
+        <TextView
+            android:id="@+id/tv_drug_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="10dp"
+            android:paddingVertical="32dp"
+            android:textSize="13sp"
+            android:text="Drug Type"
+            android:gravity="center"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"/>
+
+        <TextView android:id="@+id/tv_timestamp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center|end"
+            android:alpha="0.66"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="32dp"
+            android:text="timestamp"
+            android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            android:textSize="13sp"/>
+    </LinearLayout>
 
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,28 +1,37 @@
 <resources>
     <string name="app_name">InteRxactions</string>
 
+    <!-- Search Fragment/Home Screen -->
+    <string name="label_rx_search">@string/app_name</string>
+    <string name="search_label">Search for a drug to find interacting substances.</string>
     <string name="search_hint">Enter a drug name…</string>
     <string name="search_button">Find Interacting Drugs</string>
+    <string name="search_radio_label">Search by:</string>
+    <string name="search_radio_1">Brand Name</string>
+    <string name="search_radio_2">Generic Name</string>
+
+
     <string name="search_recent">Recently Searched Drugs:</string>
 
+    <!-- Search Results Fragment -->
+    <string name="label_drug_report">Interacting Drugs</string>
     <string name="adverse_button">View Adverse Events</string>
     <string name="share_button">Share Interactions</string>
-    <string name="adverse_headline">Outcomes of Drug Adverse Events For %1$s</string>
+    <string name="error_message">"Could not find '%1$s' in the FDA %2$s."</string>
 
     <string name="search_results_title">Drugs that interact with \"%1$s\"</string>
 
+    <!-- Manufacturers Fragment -->
+    <string name="label_manufacturers_list">Manufacturers</string>
     <string name="mfr_list_heading">Manufacturers of %1$s\n(Interacts with \"%2$s\")</string>
     <string name="mfr_list_sub_heading">Click a manufacturer name to expand and view details of interactions</string>
 
     <string name="action_share">Share</string>
     <string name="share_text">DRUG: %1$s\n\nPOSSIBLE INTERACTIONS: %2$s</string>
 
-    <string name="label_rx_search">InteRxactions - Search</string>
-    <string name="label_drug_report">InteRxactions - Interacting Drugs</string>
-    <string name="label_adverse_events">InteRxactions - Adverse Events</string>
-    <string name="label_manufacturers_list">InteRxactions - Manufacturers</string>
-    <string name="error_message">"Could not find '%1$s' in the FDA %2$s."</string>
-
+    <!-- Adverse Events Fragment -->
+    <string name="label_adverse_events">Adverse Events</string>
+    <string name="adverse_headline">Outcomes of Drug Adverse Events For %1$s</string>
     <string name="chart_total_events">Total Events Reported:\n%1$s</string>
     <string name="other_legend_label">Other - Other Adverse Outcomes Not Hospitalised or Fatal</string>
     <string name="hospital_legend_label">Hospitalization - Hospitalization Due to Adverse Reactions</string>


### PR DESCRIPTION
Added radio buttons to the home screen/search fragment to give the user an option to choose between brand name and generic name when searching a drug. These options do not reflect the searched drug name, rather, they are incorporated into the openFDA API query to check if that selected field exists within the `openfda` field of the interacting drugs in the response. 

This should probbly be explained when updating the UI of the fragment to include instructions and explainations. 

Other updates include:
- Refactored strings.xml to be better organized
- Updated fragment titles to reduce redundancy
- Included the drug type in the Room database
- Included an id in the Room database built from a combination of the drug name and type
- Updated the MaterialCard layout for the previously searched drugs to include the drug type

Closes #20 
Closes #17 